### PR TITLE
feat(gh): add colored output for issue and pull request states

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.4
 
 require (
 	github.com/expr-lang/expr v1.17.5
+	github.com/fatih/color v1.18.0
 	github.com/goccy/go-yaml v1.18.0
 	github.com/google/go-github/v71 v71.0.0
 	github.com/k1LoW/go-github-client/v71 v71.0.17

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/expr-lang/expr v1.17.5 h1:i1WrMvcdLF249nSNlpQZN1S6NXuW9WaOfF5tPi3aw3k=
 github.com/expr-lang/expr v1.17.5/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=


### PR DESCRIPTION
This pull request introduces changes to enhance the visual formatting of output in the `gh` package and improve code readability. The most notable updates include the addition of the `color` library for text styling, the implementation of colored output for issue and pull request states, and minor refactoring for variable handling.

### Visual Enhancements:
* **Added `color` library for text styling**: The `github.com/fatih/color` library was imported to enable colored output for better readability. [[1]](diffhunk://#diff-1e114263bdcb1a392f7956eeabd73e7df043db8186b943bbd1a3e0ab78762cceR15) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R7)
* **Introduced color-coded state markers**: Added variables (`titleC`, `numberC`, `openC`, `mergedC`, `closedC`) to define colors for different states (open, closed, merged) and applied them to the issue/pull request state markers in the output. [[1]](diffhunk://#diff-1e114263bdcb1a392f7956eeabd73e7df043db8186b943bbd1a3e0ab78762cceR34-R41) [[2]](diffhunk://#diff-1e114263bdcb1a392f7956eeabd73e7df043db8186b943bbd1a3e0ab78762cceR246-R264)

### Code Refinements:
* **Refactored variable declaration**: Adjusted the declaration of the `number` variable to avoid redundant assignments in the `action` method. [[1]](diffhunk://#diff-1e114263bdcb1a392f7956eeabd73e7df043db8186b943bbd1a3e0ab78762cceR111-R115) [[2]](diffhunk://#diff-1e114263bdcb1a392f7956eeabd73e7df043db8186b943bbd1a3e0ab78762cceL127-R137)