### PR TITLE
feat: add support for marking notifications as done

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 Key features of `gh-triage` are:
 
-- **Read**: Automatically mark Issues and Pull Requests that match specified conditions as read
+- **Done**: Mark Issues and Pull Requests that match specified conditions as done
+- **Read**: Mark Issues and Pull Requests that match specified conditions as read
 - **Open**: Open Issues and Pull Requests that match specified conditions in a browser
 - **List**: Display Issues and Pull Requests that match specified conditions in a list
 
@@ -70,10 +71,11 @@ This ensures a smooth transition without losing your existing configuration.
 ### Default configuration
 
 ```yaml
-read:
+done:
   max: 1000
-  conditions: # Auto-mark merged PRs as read
+  conditions: # Auto-mark merged and closed PRs / issues as done
     - "merged"
+    - "closed"
 
 open:
   max: 1
@@ -88,6 +90,7 @@ list:
 
 ### Options
 
+- `done`: Conditions and maximum number for marking as done
 - `read`: Conditions and maximum number for marking as read
 - `open`: Conditions and maximum number for opening in browser
 - `list`: Conditions and maximum number for listing
@@ -175,6 +178,25 @@ conditions:
 ```
 
 ## Usage Examples
+
+### Automatically mark merged Pull Requests and closed Issues as done
+
+```yaml
+done:
+  max: 1000
+  conditions:
+    - "merged"
+    - "closed"
+```
+
+### Mark failed CI Pull Requests as done
+
+```yaml
+done:
+  max: 100
+  conditions:
+    - "is_pull_request && failed"
+```
 
 ### Automatically mark merged Pull Requests as read
 

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -14,12 +14,17 @@ type Action struct {
 }
 
 type Profile struct {
-	Read Action `yaml:"read"` // Mark as read issues/pull requests that match the conditions
-	Open Action `yaml:"open"` // Open issues/pull requests that match the conditions
-	List Action `yaml:"list"` // List issues/pull requests that match the conditions
+	Done Action `yaml:"done,omitempty"` // Mark as done issues/pull requests that match the conditions
+	Read Action `yaml:"read,omitempty"` // Mark as read issues/pull requests that match the conditions
+	Open Action `yaml:"open,omitempty"` // Open issues/pull requests that match the conditions
+	List Action `yaml:"list,omitempty"` // List issues/pull requests that match the conditions
 }
 
 var defaultProfile = &Profile{
+	Done: Action{
+		Max:        0,
+		Conditions: []string{},
+	},
 	Read: Action{
 		Max: 1000,
 		Conditions: []string{

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -22,14 +22,15 @@ type Profile struct {
 
 var defaultProfile = &Profile{
 	Done: Action{
-		Max:        0,
-		Conditions: []string{},
-	},
-	Read: Action{
 		Max: 1000,
 		Conditions: []string{
 			"merged",
+			"closed",
 		},
+	},
+	Read: Action{
+		Max:        0,
+		Conditions: []string{},
 	},
 	Open: Action{
 		Max:        1,


### PR DESCRIPTION
This pull request introduces a new "done" feature to the `gh-triage` tool, allowing users to mark issues and pull requests as "done" based on specified conditions. It updates the configuration, documentation, and core logic to support this functionality.

### Documentation Updates:
* Updated `README.md` to include the new "done" feature in the feature list, configuration options, and usage examples. This includes adding YAML examples for marking merged and closed pull requests/issues as "done" and marking failed CI pull requests as "done." [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R78) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R93) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R182-R200)

### Core Logic Enhancements:
* Added a `doneLimit` field to the `Client` struct in `gh/gh.go` to track the maximum number of items to mark as "done." This is initialized in the `New` function and updated in the `action` method to handle marking notifications as "done." [[1]](diffhunk://#diff-1e114263bdcb1a392f7956eeabd73e7df043db8186b943bbd1a3e0ab78762cceR31) [[2]](diffhunk://#diff-1e114263bdcb1a392f7956eeabd73e7df043db8186b943bbd1a3e0ab78762cceR63) [[3]](diffhunk://#diff-1e114263bdcb1a392f7956eeabd73e7df043db8186b943bbd1a3e0ab78762cceR307-R320) [[4]](diffhunk://#diff-1e114263bdcb1a392f7956eeabd73e7df043db8186b943bbd1a3e0ab78762cceR332-R333)

### Configuration Changes:
* Introduced a new `done` action in the `Profile` struct in `profile/profile.go`. Updated the default profile to include conditions for marking merged and closed items as "done."