### PR TITLE
Fix: Ignore 404 Not Found errors and add --verbose flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,7 @@ var (
 	profileFlag  string
 	watch        bool
 	intervalFlag string
+	verbose      bool
 )
 
 var rootCmd = &cobra.Command{
@@ -56,7 +57,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c, err := gh.New(cfg, colorable.NewColorableStdout())
+		c, err := gh.New(cfg, colorable.NewColorableStdout(), verbose)
 		if err != nil {
 			return err
 		}
@@ -128,4 +129,5 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&profileFlag, "profile", "p", "", "Profile name for configuration file")
 	rootCmd.PersistentFlags().BoolVarP(&watch, "watch", "w", false, "Watch for notifications")
 	rootCmd.PersistentFlags().StringVarP(&intervalFlag, "interval", "i", "5min", "Interval for watching notifications (e.g., 5min, 1hour)")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "V", false, "Verbose output")
 }


### PR DESCRIPTION
This change addresses an issue where the application would crash with a 404 error when attempting to fetch details for a deleted issue, pull request, or release.

The fix introduces error handling to specifically catch `404 Not Found` responses from the GitHub API. When a 404 error is detected, the application now skips the notification, preventing the crash and allowing the triage process to continue seamlessly.

A `--verbose` flag has been added to control the logging of these `404 Not Found` errors. The warnings will only be displayed when the `--verbose` flag is enabled.